### PR TITLE
Fix/handle all decimal conversions

### DIFF
--- a/frame/ethereum/src/mock.rs
+++ b/frame/ethereum/src/mock.rs
@@ -32,7 +32,7 @@ use sp_runtime::{
 	AccountId32, BuildStorage,
 };
 // Frontier
-use pallet_evm::{AddressMapping, EnsureAddressTruncated, FeeCalculator};
+use pallet_evm::{AddressMapping, BalanceConverter, EnsureAddressTruncated, FeeCalculator};
 
 use super::*;
 use crate::IntermediateStateRoot;
@@ -158,8 +158,42 @@ parameter_types! {
 	pub SuicideQuickClearLimit: u32 = 0;
 }
 
+const EVM_DECIMALS_FACTOR: u64 = 1_000_000_000_u64;
+pub struct SubtensorEvmBalanceConverter;
+
+impl BalanceConverter for SubtensorEvmBalanceConverter {
+	/// Convert from Substrate balance (u64) to EVM balance (U256)
+	fn into_evm_balance(value: U256) -> Option<U256> {
+		value
+			.checked_mul(U256::from(EVM_DECIMALS_FACTOR))
+			.and_then(|evm_value| {
+				// Ensure the result fits within the maximum U256 value
+				if evm_value <= U256::MAX {
+					Some(evm_value)
+				} else {
+					None
+				}
+			})
+	}
+
+	/// Convert from EVM balance (U256) to Substrate balance (u64)
+	fn into_substrate_balance(value: U256) -> Option<U256> {
+		value
+			.checked_div(U256::from(EVM_DECIMALS_FACTOR))
+			.and_then(|substrate_value| {
+				// Ensure the result fits within the TAO balance type (u64)
+				if substrate_value <= U256::from(u64::MAX) {
+					Some(substrate_value)
+				} else {
+					None
+				}
+			})
+	}
+}
+
 impl pallet_evm::Config for Test {
 	type FeeCalculator = FixedGasPrice;
+	type BalanceConverter = SubtensorEvmBalanceConverter;
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;
 	type BlockHashMapping = crate::EthereumBlockHashMapping<Self>;

--- a/frame/ethereum/src/tests/eip1559.rs
+++ b/frame/ethereum/src/tests/eip1559.rs
@@ -537,7 +537,7 @@ fn validated_transaction_apply_zero_gas_price_works() {
 			max_fee_per_gas: U256::zero(),
 			gas_limit: U256::from(21_000),
 			action: ethereum::TransactionAction::Call(bob.address),
-			value: U256::from(100),
+			value: U256::from(100e9 as u128),
 			input: Default::default(),
 		}
 		.sign(&alice.private_key, None);

--- a/frame/ethereum/src/tests/eip2930.rs
+++ b/frame/ethereum/src/tests/eip2930.rs
@@ -462,7 +462,7 @@ fn validated_transaction_apply_zero_gas_price_works() {
 			gas_price: U256::zero(),
 			gas_limit: U256::from(21_000),
 			action: ethereum::TransactionAction::Call(bob.address),
-			value: U256::from(100),
+			value: U256::from(100e9 as u128),
 			input: Default::default(),
 		}
 		.sign(&alice.private_key, None);

--- a/frame/ethereum/src/tests/legacy.rs
+++ b/frame/ethereum/src/tests/legacy.rs
@@ -462,7 +462,7 @@ fn validated_transaction_apply_zero_gas_price_works() {
 			gas_price: U256::zero(),
 			gas_limit: U256::from(21_000),
 			action: ethereum::TransactionAction::Call(bob.address),
-			value: U256::from(100),
+			value: U256::from(100e9 as u128),
 			input: Default::default(),
 		}
 		.sign(&alice.private_key);

--- a/frame/evm/precompile/storage-cleaner/src/mock.rs
+++ b/frame/evm/precompile/storage-cleaner/src/mock.rs
@@ -19,7 +19,7 @@
 
 use crate::{StorageCleanerPrecompile, StorageCleanerPrecompileCall};
 use frame_support::{parameter_types, weights::Weight};
-use pallet_evm::{EnsureAddressNever, EnsureAddressRoot, IdentityAddressMapping};
+use pallet_evm::{BalanceConverter, EnsureAddressNever, EnsureAddressRoot, IdentityAddressMapping};
 use precompile_utils::{precompile_set::*, testing::*};
 use sp_core::{ConstU32, H256, U256};
 use sp_runtime::{
@@ -123,7 +123,41 @@ parameter_types! {
 	pub SuicideQuickClearLimit: u32 = 0;
 }
 
+const EVM_DECIMALS_FACTOR: u64 = 1_000_000_000_u64;
+pub struct SubtensorEvmBalanceConverter;
+
+impl BalanceConverter for SubtensorEvmBalanceConverter {
+	/// Convert from Substrate balance (u64) to EVM balance (U256)
+	fn into_evm_balance(value: U256) -> Option<U256> {
+		value
+			.checked_mul(U256::from(EVM_DECIMALS_FACTOR))
+			.and_then(|evm_value| {
+				// Ensure the result fits within the maximum U256 value
+				if evm_value <= U256::MAX {
+					Some(evm_value)
+				} else {
+					None
+				}
+			})
+	}
+
+	/// Convert from EVM balance (U256) to Substrate balance (u64)
+	fn into_substrate_balance(value: U256) -> Option<U256> {
+		value
+			.checked_div(U256::from(EVM_DECIMALS_FACTOR))
+			.and_then(|substrate_value| {
+				// Ensure the result fits within the TAO balance type (u64)
+				if substrate_value <= U256::from(u64::MAX) {
+					Some(substrate_value)
+				} else {
+					None
+				}
+			})
+	}
+}
+
 impl pallet_evm::Config for Runtime {
+	type BalanceConverter = SubtensorEvmBalanceConverter;
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -1050,8 +1050,8 @@ where
 			let account_id = T::AddressMapping::into_account_id(*who);
 
 			// Convert corrected fee into substrate balance
-			let corrected_fee_sub = T::BalanceConverter::into_substrate_balance(corrected_fee)
-				.ok_or(Error::<T>::FeeOverflow)?;
+			let corrected_fee_sub =
+				T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(U256::from(0));
 
 			// Calculate how much refund we should return
 			let refund_amount = paid
@@ -1089,8 +1089,8 @@ where
 				.unwrap_or_else(|_| C::NegativeImbalance::zero());
 
 			// Convert base fee into substrate balance
-			let base_fee_sub = T::BalanceConverter::into_substrate_balance(base_fee)
-				.ok_or(Error::<T>::FeeOverflow)?;
+			let base_fee_sub =
+				T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(U256::from(0));
 
 			let (base_fee, tip) = adjusted_paid.split(base_fee_sub.unique_saturated_into());
 			// Handle base fee. Can be either burned, rationed, etc ...
@@ -1158,8 +1158,8 @@ where
 			let account_id = T::AddressMapping::into_account_id(*who);
 
 			// Convert corrected fee into substrate balance
-			let corrected_fee_sub = T::BalanceConverter::into_substrate_balance(corrected_fee)
-				.ok_or(Error::<T>::FeeOverflow)?;
+			let corrected_fee_sub =
+				T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(U256::from(0));
 
 			// Calculate how much refund we should return
 			let refund_amount = paid
@@ -1176,8 +1176,8 @@ where
 				.unwrap_or_else(|_| Credit::<T::AccountId, F>::zero());
 
 			// Convert base fee into substrate balance
-			let base_fee_sub = T::BalanceConverter::into_substrate_balance(base_fee)
-				.ok_or(Error::<T>::FeeOverflow)?;
+			let base_fee_sub =
+				T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(U256::from(0));
 
 			let (base_fee, tip) = adjusted_paid.split(base_fee_sub.unique_saturated_into());
 			// Handle base fee. Can be either burned, rationed, etc ...

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -951,7 +951,8 @@ impl<T: Config> Pallet<T> {
 		let balance =
 			T::Currency::reducible_balance(&account_id, Preservation::Preserve, Fortitude::Polite);
 		let balance_u256 = U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(balance));
-		let balance_eth = T::BalanceConverter::into_evm_balance(balance_u256).unwrap_or(U256::from(0));
+		let balance_eth =
+			T::BalanceConverter::into_evm_balance(balance_u256).unwrap_or(U256::from(0));
 
 		(
 			Account {
@@ -1257,10 +1258,11 @@ pub trait BalanceConverter {
 	fn into_substrate_balance(value: U256) -> Option<U256>;
 }
 
-impl BalanceConverter for ()
-{
+impl BalanceConverter for () {
 	fn into_evm_balance(value: U256) -> Option<U256> {
-		Some(U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(value)))
+		Some(U256::from(
+			UniqueSaturatedInto::<u128>::unique_saturated_into(value),
+		))
 	}
 
 	fn into_substrate_balance(value: U256) -> Option<U256> {

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -1051,8 +1051,8 @@ where
 			let account_id = T::AddressMapping::into_account_id(*who);
 
 			// Convert corrected fee into substrate balance
-			let corrected_fee_sub =
-				T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(U256::from(0));
+			 let corrected_fee_sub = corrected_fee;
+			/// T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(U256::from(0));
 
 			// Calculate how much refund we should return
 			let refund_amount = paid
@@ -1090,8 +1090,8 @@ where
 				.unwrap_or_else(|_| C::NegativeImbalance::zero());
 
 			// Convert base fee into substrate balance
-			let base_fee_sub =
-				T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(U256::from(0));
+			let base_fee_sub = base_fee;
+			/// T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(U256::from(0));
 
 			let (base_fee, tip) = adjusted_paid.split(base_fee_sub.unique_saturated_into());
 			// Handle base fee. Can be either burned, rationed, etc ...
@@ -1159,8 +1159,8 @@ where
 			let account_id = T::AddressMapping::into_account_id(*who);
 
 			// Convert corrected fee into substrate balance
-			let corrected_fee_sub =
-				T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(U256::from(0));
+			let corrected_fee_sub = corrected_fee;
+			/// T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(U256::from(0));
 
 			// Calculate how much refund we should return
 			let refund_amount = paid
@@ -1177,8 +1177,8 @@ where
 				.unwrap_or_else(|_| Credit::<T::AccountId, F>::zero());
 
 			// Convert base fee into substrate balance
-			let base_fee_sub =
-				T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(U256::from(0));
+			let base_fee_sub = base_fee;
+			/// T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(U256::from(0));
 
 			let (base_fee, tip) = adjusted_paid.split(base_fee_sub.unique_saturated_into());
 			// Handle base fee. Can be either burned, rationed, etc ...

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -1051,8 +1051,8 @@ where
 			let account_id = T::AddressMapping::into_account_id(*who);
 
 			// Convert corrected fee into substrate balance
-			 let corrected_fee_sub = corrected_fee;
-			/// T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(U256::from(0));
+			let corrected_fee_sub =
+				T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(U256::from(0));
 
 			// Calculate how much refund we should return
 			let refund_amount = paid
@@ -1090,8 +1090,8 @@ where
 				.unwrap_or_else(|_| C::NegativeImbalance::zero());
 
 			// Convert base fee into substrate balance
-			let base_fee_sub = base_fee;
-			/// T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(U256::from(0));
+			let base_fee_sub =
+				T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(U256::from(0));
 
 			let (base_fee, tip) = adjusted_paid.split(base_fee_sub.unique_saturated_into());
 			// Handle base fee. Can be either burned, rationed, etc ...
@@ -1159,8 +1159,8 @@ where
 			let account_id = T::AddressMapping::into_account_id(*who);
 
 			// Convert corrected fee into substrate balance
-			let corrected_fee_sub = corrected_fee;
-			/// T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(U256::from(0));
+			let corrected_fee_sub =
+				T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(U256::from(0));
 
 			// Calculate how much refund we should return
 			let refund_amount = paid
@@ -1177,8 +1177,8 @@ where
 				.unwrap_or_else(|_| Credit::<T::AccountId, F>::zero());
 
 			// Convert base fee into substrate balance
-			let base_fee_sub = base_fee;
-			/// T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(U256::from(0));
+			let base_fee_sub =
+				T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(U256::from(0));
 
 			let (base_fee, tip) = adjusted_paid.split(base_fee_sub.unique_saturated_into());
 			// Handle base fee. Can be either burned, rationed, etc ...

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -48,7 +48,7 @@ use fp_evm::{
 
 use crate::{
 	runner::Runner as RunnerT, AccountCodes, AccountCodesMetadata, AccountStorages, AddressMapping,
-	BalanceOf, BalanceConverter, BlockHashMapping, Config, Error, Event, FeeCalculator, 
+	BalanceConverter, BalanceOf, BlockHashMapping, Config, Error, Event, FeeCalculator,
 	OnChargeEVMTransaction, OnCreate, Pallet, RunnerError,
 };
 
@@ -927,7 +927,8 @@ where
 		let target = T::AddressMapping::into_account_id(transfer.target);
 
 		// Adjust decimals
-		let value_sub = T::BalanceConverter::into_substrate_balance(transfer.value).ok_or(ExitError::OutOfFund)?;
+		let value_sub = T::BalanceConverter::into_substrate_balance(transfer.value)
+			.ok_or(ExitError::OutOfFund)?;
 
 		T::Currency::transfer(
 			&source,

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -230,6 +230,7 @@ where
 				})?;
 
 		// Deduct fee from the `source` account. Returns `None` if `total_fee` is Zero.
+		// === Note: This fee gets converted to substrate decimals in `withdraw_fee` ===
 		let fee = T::OnChargeTransaction::withdraw_fee(&source, total_fee)
 			.map_err(|e| RunnerError { error: e, weight })?;
 
@@ -295,6 +296,8 @@ where
 		// Refunded 200 - 40 = 160.
 		// Tip 5 * 6 = 30.
 		// Burned 200 - (160 + 30) = 10. Which is equivalent to gas_used * base_fee.
+		// === Note: we expect acutal_fee and actual_base_fee to be in EVM decimals. but `fee` should be in substrate decimals already ===
+		// === Note: `actual_priority_fee` gets converted to substrate decimals in `correct_and_deposit_fee` ===
 		let actual_priority_fee = T::OnChargeTransaction::correct_and_deposit_fee(
 			&source,
 			// Actual fee after evm execution, including tip.
@@ -304,6 +307,7 @@ where
 			// Fee initially withdrawn.
 			fee,
 		);
+		// === Note: `actual_priority_fee` is already in substrate decimals ===
 		T::OnChargeTransaction::pay_priority_fee(actual_priority_fee);
 
 		let state = executor.into_state();

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -89,6 +89,9 @@ mod proof_size_test {
 		gas_limit: u64,
 		weight_limit: Option<Weight>,
 	) -> Result<CreateInfo, crate::RunnerError<crate::Error<Test>>> {
+		let whitelist = Vec::new();
+		let whitelist_disabled = true;
+
 		<Test as Config>::Runner::create(
 			H160::default(),
 			hex::decode(PROOF_SIZE_TEST_CALLEE_CONTRACT_BYTECODE.trim_end()).unwrap(),
@@ -98,6 +101,8 @@ mod proof_size_test {
 			None,
 			None,
 			Vec::new(),
+			whitelist,
+			whitelist_disabled,
 			true, // transactional
 			true, // must be validated
 			weight_limit,
@@ -110,6 +115,9 @@ mod proof_size_test {
 		gas_limit: u64,
 		weight_limit: Option<Weight>,
 	) -> Result<CreateInfo, crate::RunnerError<crate::Error<Test>>> {
+		let whitelist = Vec::new();
+		let whitelist_disabled = true;
+
 		<Test as Config>::Runner::create(
 			H160::default(),
 			hex::decode(PROOF_SIZE_TEST_CONTRACT_BYTECODE.trim_end()).unwrap(),
@@ -119,6 +127,8 @@ mod proof_size_test {
 			None,
 			None,
 			Vec::new(),
+			whitelist,
+			whitelist_disabled,
 			true, // non-transactional
 			true, // must be validated
 			weight_limit,
@@ -714,6 +724,7 @@ fn fail_call_return_ok() {
 	});
 }
 
+// cargo test --package pallet-evm --lib -- tests::fee_deduction --exact --show-output
 #[test]
 fn fee_deduction() {
 	new_test_ext().execute_with(|| {
@@ -726,11 +737,11 @@ fn fee_deduction() {
 		assert_eq!(Balances::free_balance(substrate_addr), 100);
 
 		// Deduct fees as 10 units
-		let imbalance = <<Test as Config>::OnChargeTransaction as OnChargeEVMTransaction<Test>>::withdraw_fee(&evm_addr, U256::from(10)).unwrap();
+		let imbalance = <<Test as Config>::OnChargeTransaction as OnChargeEVMTransaction<Test>>::withdraw_fee(&evm_addr, U256::from(10e9 as u64)).unwrap();
 		assert_eq!(Balances::free_balance(substrate_addr), 90);
 
 		// Refund fees as 5 units
-		<<Test as Config>::OnChargeTransaction as OnChargeEVMTransaction<Test>>::correct_and_deposit_fee(&evm_addr, U256::from(5), U256::from(5), imbalance);
+		<<Test as Config>::OnChargeTransaction as OnChargeEVMTransaction<Test>>::correct_and_deposit_fee(&evm_addr, U256::from(5e9 as u64), U256::from(5e9 as u64), imbalance);
 		assert_eq!(Balances::free_balance(substrate_addr), 95);
 	});
 }

--- a/precompiles/tests-external/lib.rs
+++ b/precompiles/tests-external/lib.rs
@@ -34,7 +34,7 @@ use sp_runtime::{
 };
 // Frontier
 use fp_evm::{ExitReason, ExitRevert, PrecompileFailure, PrecompileHandle};
-use pallet_evm::{EnsureAddressNever, EnsureAddressRoot};
+use pallet_evm::{BalanceConverter, EnsureAddressNever, EnsureAddressRoot};
 use precompile_utils::{
 	precompile_set::*,
 	solidity::{codec::Writer, revert::revert},
@@ -229,7 +229,41 @@ parameter_types! {
 	pub SuicideQuickClearLimit: u32 = 0;
 }
 
+const EVM_DECIMALS_FACTOR: u64 = 1_000_000_000_u64;
+pub struct SubtensorEvmBalanceConverter;
+
+impl BalanceConverter for SubtensorEvmBalanceConverter {
+	/// Convert from Substrate balance (u64) to EVM balance (U256)
+	fn into_evm_balance(value: U256) -> Option<U256> {
+		value
+			.checked_mul(U256::from(EVM_DECIMALS_FACTOR))
+			.and_then(|evm_value| {
+				// Ensure the result fits within the maximum U256 value
+				if evm_value <= U256::MAX {
+					Some(evm_value)
+				} else {
+					None
+				}
+			})
+	}
+
+	/// Convert from EVM balance (U256) to Substrate balance (u64)
+	fn into_substrate_balance(value: U256) -> Option<U256> {
+		value
+			.checked_div(U256::from(EVM_DECIMALS_FACTOR))
+			.and_then(|substrate_value| {
+				// Ensure the result fits within the TAO balance type (u64)
+				if substrate_value <= U256::from(u64::MAX) {
+					Some(substrate_value)
+				} else {
+					None
+				}
+			})
+	}
+}
+
 impl pallet_evm::Config for Runtime {
+	type BalanceConverter = SubtensorEvmBalanceConverter;
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
 	type WeightPerGas = WeightPerGas;


### PR DESCRIPTION
This PR fixes an issue with the gas charging on the EVM layer.   
The gas was withdrawn at the limit, but the unused gas was not refunded.  
This happened because the refund calculation never converted the remainder to the right magnitude, meaning the refund was `<1 RAO` and refunded as `0 RAO`