### PR TITLE
Upgrade Polkadot SDK to stable2409-7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,6 +2237,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fc-aura"
+version = "1.0.0-dev"
+dependencies = [
+ "fc-rpc",
+ "fp-storage",
+ "sc-client-api",
+ "sc-consensus-aura",
+ "sp-api",
+ "sp-consensus-aura",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-timestamp",
+]
+
+[[package]]
 name = "fc-cli"
 version = "1.0.0-dev"
 dependencies = [
@@ -2969,6 +2984,7 @@ dependencies = [
  "async-trait",
  "clap",
  "fc-api",
+ "fc-aura",
  "fc-cli",
  "fc-consensus",
  "fc-db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2708,7 +2708,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2782,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "docify",
@@ -2826,8 +2826,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "38.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -2867,8 +2867,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "30.0.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "30.0.6"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2888,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2910,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "cfg-if",
  "docify",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -2954,7 +2954,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5752,7 +5752,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-aura"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5768,7 +5768,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5781,7 +5781,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5803,8 +5803,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "39.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6063,7 +6063,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6100,7 +6100,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6136,7 +6136,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6154,8 +6154,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "38.0.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6186,7 +6186,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6198,7 +6198,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7698,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "log",
  "sp-core",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7731,7 +7731,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7746,7 +7746,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "docify",
@@ -7773,7 +7773,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -7784,7 +7784,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -7825,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "fnv",
  "futures",
@@ -7851,8 +7851,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "0.44.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -7878,7 +7878,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "futures",
@@ -7902,7 +7902,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "futures",
@@ -7931,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -7967,7 +7967,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -7980,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -8059,7 +8059,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "futures",
@@ -8082,7 +8082,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -8105,7 +8105,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -8118,7 +8118,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "log",
  "polkavm",
@@ -8129,7 +8129,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8147,7 +8147,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "console",
  "futures",
@@ -8164,7 +8164,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -8178,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "arrayvec",
@@ -8206,8 +8206,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "0.45.6"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8258,7 +8258,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -8276,7 +8276,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "ahash",
  "futures",
@@ -8294,8 +8294,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-light"
-version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "0.44.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8315,8 +8315,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-sync"
-version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "0.44.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8352,8 +8352,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "0.44.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8372,7 +8372,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -8389,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -8423,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8432,7 +8432,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8464,7 +8464,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8483,8 +8483,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "17.1.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -8508,7 +8508,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8540,7 +8540,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "directories",
@@ -8604,7 +8604,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8615,7 +8615,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "derive_more",
  "futures",
@@ -8636,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "chrono",
  "futures",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "chrono",
  "console",
@@ -8685,7 +8685,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -8696,7 +8696,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "futures",
@@ -8723,7 +8723,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "futures",
@@ -8739,7 +8739,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-channel",
  "futures",
@@ -9286,7 +9286,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "docify",
  "hash-db",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -9322,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -9348,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -9358,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "futures",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9408,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9443,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9454,7 +9454,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -9500,7 +9500,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -9523,7 +9523,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -9532,7 +9532,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9542,7 +9542,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9552,7 +9552,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9564,7 +9564,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9576,8 +9576,8 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "38.0.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "bytes",
  "docify",
@@ -9603,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -9613,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -9624,7 +9624,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -9633,7 +9633,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -9643,7 +9643,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9654,7 +9654,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9664,7 +9664,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -9674,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -9683,8 +9683,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "39.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "39.0.5"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "docify",
  "either",
@@ -9710,7 +9710,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9729,7 +9729,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "Inflector",
  "expander",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9756,7 +9756,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9769,7 +9769,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "hash-db",
  "log",
@@ -9789,7 +9789,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "aes-gcm 0.10.2",
  "curve25519-dalek",
@@ -9813,12 +9813,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9830,7 +9830,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9842,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -9853,7 +9853,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -9862,7 +9862,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9876,7 +9876,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "ahash",
  "hash-db",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9916,7 +9916,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -9927,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -9939,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -10128,8 +10128,8 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-xcm"
-version = "14.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "14.2.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -10274,12 +10274,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -10299,7 +10299,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "http-body-util",
  "hyper 1.4.1",
@@ -10313,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -10340,7 +10340,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "frame-executive",
@@ -10384,7 +10384,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "futures",
  "sc-block-builder",
@@ -10401,8 +10401,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "24.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+version = "24.0.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -12037,7 +12037,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409#87971b3e92721bdf10bf40b410eaae779d494ca0"
+source = "git+https://github.com/paritytech/polkadot-sdk?tag=polkadot-stable2409-7#0c9644766f02c872f51e5b72adf1051189fe9126"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,81 +83,81 @@ thiserror = "1.0"
 tokio = "1.38.0"
 
 # Substrate Client
-sc-basic-authorship = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-chain-spec = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-client-db = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-consensus-manual-seal = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-keystore = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-network = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-network-common = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-network-sync = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-rpc = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-rpc-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-service = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sc-utils = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
+sc-basic-authorship = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-chain-spec = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-client-db = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-consensus-manual-seal = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-keystore = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-network = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-network-common = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-network-sync = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-rpc = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-rpc-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-service = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sc-telemetry = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sc-utils = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
 # Substrate Primitive
-sp-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sp-consensus = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-crypto-hashing = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-database = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sp-externalities = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-session = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-state-machine = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-std = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-storage = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-version = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-block-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sp-consensus = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-crypto-hashing = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-database = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sp-externalities = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+sp-offchain = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-runtime-interface = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-session = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-state-machine = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-storage = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-version = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
 # Substrate FRAME
-frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-pallet-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-pallet-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
-pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+frame-executive = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+pallet-aura = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+pallet-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
 # Substrate Utility
-frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-substrate-test-runtime-client = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
-substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7" }
 
 # XCM
-xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409", default-features = false }
+xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-7", default-features = false }
 
 # Arkworks
 ark-bls12-377 = { version = "0.4.0", default-features = false, features = ["curve"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
 	"frame/evm-chain-id",
 	"frame/hotfix-sufficients",
 	"client/api",
+	"client/aura",
 	"client/consensus",
 	"client/rpc-core",
 	"client/rpc",
@@ -169,6 +170,7 @@ ark-std = { version = "0.4.0", default-features = false }
 
 # Frontier Client
 fc-api = { path = "client/api" }
+fc-aura = { path = "client/aura" }
 fc-cli = { path = "client/cli", default-features = false }
 fc-consensus = { path = "client/consensus" }
 fc-db = { path = "client/db", default-features = false }

--- a/client/aura/Cargo.toml
+++ b/client/aura/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fc-aura"
+version = "1.0.0-dev"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+description = "Frontier Aura Consensus Data Provider"
+authors = { workspace = true }
+edition = { workspace = true }
+repository = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+# Substrate
+sc-client-api = { workspace = true }
+sc-consensus-aura = { workspace = true }
+sp-api = { workspace = true, features = ["default"] }
+sp-consensus-aura = { workspace = true, features = ["default"] }
+sp-inherents = { workspace = true, features = ["default"] }
+sp-runtime = { workspace = true, features = ["default"] }
+sp-timestamp = { workspace = true, features = ["default"] }
+# Frontier
+fc-rpc = { workspace = true }
+fp-storage = { workspace = true, features = ["default"] }

--- a/client/aura/src/lib.rs
+++ b/client/aura/src/lib.rs
@@ -1,0 +1,61 @@
+use std::{marker::PhantomData, sync::Arc};
+
+// Substrate
+use sc_client_api::{AuxStore, UsageProvider};
+use sp_api::ProvideRuntimeApi;
+use sp_consensus_aura::{
+	digests::CompatibleDigestItem,
+	sr25519::{AuthorityId, AuthoritySignature},
+	AuraApi, Slot, SlotDuration,
+};
+use sp_inherents::InherentData;
+use sp_runtime::{traits::Block as BlockT, Digest, DigestItem};
+use sp_timestamp::TimestampInherentData;
+// Frontier
+use fc_rpc::pending::ConsensusDataProvider;
+
+/// Consensus data provider for Aura.
+pub struct AuraConsensusDataProvider<B, C> {
+	// slot duration
+	slot_duration: SlotDuration,
+	// phantom data for required generics
+	_phantom: PhantomData<(B, C)>,
+}
+
+impl<B, C> AuraConsensusDataProvider<B, C>
+where
+	B: BlockT,
+	C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B>,
+	C::Api: AuraApi<B, AuthorityId>,
+{
+	/// Creates a new instance of the [`AuraConsensusDataProvider`], requires that `client`
+	/// implements [`sp_consensus_aura::AuraApi`]
+	pub fn new(client: Arc<C>) -> Self {
+		let slot_duration = sc_consensus_aura::slot_duration(&*client)
+			.expect("slot_duration is always present; qed.");
+		Self {
+			slot_duration,
+			_phantom: PhantomData,
+		}
+	}
+}
+
+impl<B: BlockT, C: Send + Sync> ConsensusDataProvider<B> for AuraConsensusDataProvider<B, C> {
+	fn create_digest(
+		&self,
+		_parent: &B::Header,
+		data: &InherentData,
+	) -> Result<Digest, sp_inherents::Error> {
+		let timestamp = data
+			.timestamp_inherent_data()?
+			.expect("Timestamp is always present; qed");
+
+		let digest_item = <DigestItem as CompatibleDigestItem<AuthoritySignature>>::aura_pre_digest(
+			Slot::from_timestamp(timestamp, self.slot_duration),
+		);
+
+		Ok(Digest {
+			logs: vec![digest_item],
+		})
+	}
+}

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -950,7 +950,8 @@ impl<T: Config> Pallet<T> {
 		let nonce = frame_system::Pallet::<T>::account_nonce(&account_id);
 		let balance =
 			T::Currency::reducible_balance(&account_id, Preservation::Preserve, Fortitude::Polite);
-		let balance_sub = SubstrateBalance::from(UniqueSaturatedInto::<u128>::unique_saturated_into(balance));
+		let balance_sub =
+			SubstrateBalance::from(UniqueSaturatedInto::<u128>::unique_saturated_into(balance));
 		let balance_eth =
 			T::BalanceConverter::into_evm_balance(balance_sub).unwrap_or(EvmBalance::from(0u64));
 
@@ -1051,8 +1052,8 @@ where
 			let account_id = T::AddressMapping::into_account_id(*who);
 
 			// Convert corrected fee into substrate balance
-			let corrected_fee_sub =
-				T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(SubstrateBalance::from(0u64));
+			let corrected_fee_sub = T::BalanceConverter::into_substrate_balance(corrected_fee)
+				.unwrap_or(SubstrateBalance::from(0u64));
 
 			// Calculate how much refund we should return
 			let refund_amount = paid
@@ -1090,8 +1091,8 @@ where
 				.unwrap_or_else(|_| C::NegativeImbalance::zero());
 
 			// Convert base fee into substrate balance
-			let base_fee_sub =
-				T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(SubstrateBalance::from(0u64));
+			let base_fee_sub = T::BalanceConverter::into_substrate_balance(base_fee)
+				.unwrap_or(SubstrateBalance::from(0u64));
 
 			let (base_fee, tip) = adjusted_paid.split(base_fee_sub.0.unique_saturated_into());
 			// Handle base fee. Can be either burned, rationed, etc ...
@@ -1159,8 +1160,8 @@ where
 			let account_id = T::AddressMapping::into_account_id(*who);
 
 			// Convert corrected fee into substrate balance
-			let corrected_fee_sub =
-				T::BalanceConverter::into_substrate_balance(corrected_fee).unwrap_or(SubstrateBalance::from(0u64));
+			let corrected_fee_sub = T::BalanceConverter::into_substrate_balance(corrected_fee)
+				.unwrap_or(SubstrateBalance::from(0u64));
 
 			// Calculate how much refund we should return
 			let refund_amount = paid
@@ -1177,8 +1178,8 @@ where
 				.unwrap_or_else(|_| Credit::<T::AccountId, F>::zero());
 
 			// Convert base fee into substrate balance
-			let base_fee_sub =
-				T::BalanceConverter::into_substrate_balance(base_fee).unwrap_or(SubstrateBalance::from(0u64));
+			let base_fee_sub = T::BalanceConverter::into_substrate_balance(base_fee)
+				.unwrap_or(SubstrateBalance::from(0u64));
 
 			let (base_fee, tip) = adjusted_paid.split(base_fee_sub.0.unique_saturated_into());
 			// Handle base fee. Can be either burned, rationed, etc ...
@@ -1250,7 +1251,7 @@ impl<T> OnCreate<T> for Tuple {
 	}
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SubstrateBalance(U256);
 
 impl SubstrateBalance {
@@ -1289,7 +1290,7 @@ impl From<SubstrateBalance> for U256 {
 	}
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EvmBalance(U256);
 
 impl EvmBalance {

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -1251,7 +1251,7 @@ impl<T> OnCreate<T> for Tuple {
 	}
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct SubstrateBalance(U256);
 
 impl SubstrateBalance {
@@ -1290,7 +1290,7 @@ impl From<SubstrateBalance> for U256 {
 	}
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct EvmBalance(U256);
 
 impl EvmBalance {

--- a/template/node/Cargo.toml
+++ b/template/node/Cargo.toml
@@ -67,6 +67,7 @@ pallet-transaction-payment = { workspace = true }
 
 # Frontier
 fc-api = { workspace = true }
+fc-aura = { workspace = true }
 fc-cli = { workspace = true }
 fc-consensus = { workspace = true }
 fc-db = { workspace = true }

--- a/template/node/src/rpc/eth.rs
+++ b/template/node/src/rpc/eth.rs
@@ -66,67 +66,6 @@ pub struct EthDeps<B: BlockT, C, P, A: ChainApi, CT, CIDP> {
 	pub pending_create_inherent_data_providers: CIDP,
 }
 
-mod aura {
-	use super::*;
-	use fc_rpc::pending::ConsensusDataProvider;
-	use sp_consensus_aura::{
-		digests::CompatibleDigestItem,
-		sr25519::{AuthorityId, AuthoritySignature},
-		AuraApi, Slot, SlotDuration,
-	};
-	use sp_inherents::InherentData;
-	use sp_runtime::{Digest, DigestItem};
-	use sp_timestamp::TimestampInherentData;
-	use std::marker::PhantomData;
-
-	/// Consensus data provider for Aura.
-	pub struct AuraConsensusDataProvider<B, C> {
-		// slot duration
-		slot_duration: SlotDuration,
-		// phantom data for required generics
-		_phantom: PhantomData<(B, C)>,
-	}
-
-	impl<B, C> AuraConsensusDataProvider<B, C>
-	where
-		B: BlockT,
-		C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B>,
-		C::Api: AuraApi<B, AuthorityId>,
-	{
-		/// Creates a new instance of the [`AuraConsensusDataProvider`], requires that `client`
-		/// implements [`sp_consensus_aura::AuraApi`]
-		pub fn new(client: Arc<C>) -> Self {
-			let slot_duration = sc_consensus_aura::slot_duration(&*client)
-				.expect("slot_duration is always present; qed.");
-			Self {
-				slot_duration,
-				_phantom: PhantomData,
-			}
-		}
-	}
-
-	impl<B: BlockT, C: Send + Sync> ConsensusDataProvider<B> for AuraConsensusDataProvider<B, C> {
-		fn create_digest(
-			&self,
-			_parent: &B::Header,
-			data: &InherentData,
-		) -> Result<Digest, sp_inherents::Error> {
-			let timestamp = data
-				.timestamp_inherent_data()?
-				.expect("Timestamp is always present; qed");
-
-			let digest_item =
-				<DigestItem as CompatibleDigestItem<AuthoritySignature>>::aura_pre_digest(
-					Slot::from_timestamp(timestamp, self.slot_duration),
-				);
-
-			Ok(Digest {
-				logs: vec![digest_item],
-			})
-		}
-	}
-}
-
 /// Instantiate Ethereum-compatible RPC extensions.
 pub fn create_eth<B, C, BE, P, A, CT, CIDP, EC>(
 	mut io: RpcModule<()>,
@@ -204,7 +143,7 @@ where
 			execute_gas_limit_multiplier,
 			forced_parent_hashes,
 			pending_create_inherent_data_providers,
-			Some(Box::new(aura::AuraConsensusDataProvider::new(
+			Some(Box::new(fc_aura::AuraConsensusDataProvider::new(
 				client.clone(),
 			))),
 		)


### PR DESCRIPTION
This PR introduces the update from the Polkadot SDK version stable2409 to the stable2409-7.

- Bump substrate dependencies versions

- Fix the issue with the AuraConsensusDataProvider not exported from the fork to the subtensor node by creating a new crate `fc-aura` in the `client`, use this in the node template from the repository and make it possible to use it from the subtensor node.

- Derive common traits (Eq/Ord/Debug) for the SubstrateBalance/EvmBalance to make it possible to use them in assertions.