### PR TITLE
Pin evm version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,6 +2668,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee371ebb7479ed3258617557ab0b3247e741075cb6b02b820d188f68da44441"
+dependencies = [
+ "bytes",
+ "ethereum-types",
+ "hash-db",
+ "hash256-std-hasher",
+ "k256",
+ "parity-scale-codec",
+ "rlp",
+ "scale-info",
+ "serde",
+ "sha3",
+ "trie-root",
+]
+
+[[package]]
 name = "ethereum-types"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,12 +2731,12 @@ dependencies = [
 
 [[package]]
 name = "evm"
-version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6ca5a72bc8942f4860137155dd9033526fd362a5"
+version = "0.43.4"
+source = "git+https://github.com/rust-ethereum/evm?rev=d966171a50596a75c1039acd6cacee22b529e225#d966171a50596a75c1039acd6cacee22b529e225"
 dependencies = [
  "auto_impl",
  "environmental",
- "ethereum",
+ "ethereum 0.18.2",
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
@@ -2732,8 +2751,8 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6ca5a72bc8942f4860137155dd9033526fd362a5"
+version = "0.43.0"
+source = "git+https://github.com/rust-ethereum/evm?rev=d966171a50596a75c1039acd6cacee22b529e225#d966171a50596a75c1039acd6cacee22b529e225"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -2743,8 +2762,8 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6ca5a72bc8942f4860137155dd9033526fd362a5"
+version = "0.43.0"
+source = "git+https://github.com/rust-ethereum/evm?rev=d966171a50596a75c1039acd6cacee22b529e225#d966171a50596a75c1039acd6cacee22b529e225"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2754,8 +2773,8 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?branch=v0.x#6ca5a72bc8942f4860137155dd9033526fd362a5"
+version = "0.43.0"
+source = "git+https://github.com/rust-ethereum/evm?rev=d966171a50596a75c1039acd6cacee22b529e225#d966171a50596a75c1039acd6cacee22b529e225"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -2918,7 +2937,7 @@ name = "fc-db"
 version = "2.0.0-dev"
 dependencies = [
  "async-trait",
- "ethereum",
+ "ethereum 0.15.0",
  "fc-api",
  "fc-storage",
  "fp-consensus",
@@ -2951,7 +2970,7 @@ dependencies = [
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.15.0",
  "ethereum-types",
  "fc-db",
  "fc-storage",
@@ -2984,7 +3003,7 @@ dependencies = [
 name = "fc-rpc"
 version = "2.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.15.0",
  "ethereum-types",
  "evm",
  "fc-api",
@@ -3040,7 +3059,7 @@ dependencies = [
 name = "fc-rpc-core"
 version = "1.1.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.15.0",
  "ethereum-types",
  "jsonrpsee",
  "rlp",
@@ -3077,7 +3096,7 @@ dependencies = [
 name = "fc-storage"
 version = "1.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.15.0",
  "ethereum-types",
  "fp-rpc",
  "fp-storage",
@@ -3268,7 +3287,7 @@ dependencies = [
 name = "fp-consensus"
 version = "2.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.15.0",
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
@@ -3287,7 +3306,7 @@ dependencies = [
 name = "fp-ethereum"
 version = "1.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.15.0",
  "ethereum-types",
  "fp-evm",
  "frame-support",
@@ -3313,7 +3332,7 @@ dependencies = [
 name = "fp-rpc"
 version = "3.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.15.0",
  "ethereum-types",
  "fp-evm",
  "parity-scale-codec",
@@ -6915,7 +6934,7 @@ dependencies = [
 name = "pallet-ethereum"
 version = "4.0.0-dev"
 dependencies = [
- "ethereum",
+ "ethereum 0.15.0",
  "ethereum-types",
  "evm",
  "fp-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ derive_more = "1.0"
 environmental = { version = "1.1.4", default-features = false }
 ethereum = { git = "https://github.com/rust-ethereum/ethereum", rev = "bbb544622208ef6e9890a2dbc224248f6dd13318", default-features = false }
 ethereum-types = { version = "0.15", default-features = false }
-evm = { git = "https://github.com/rust-ethereum/evm", branch = "v0.x", default-features = false }
+evm = { git = "https://github.com/rust-ethereum/evm", rev = "6ca5a72bc8942f4860137155dd9033526fd362a5", default-features = false }
 futures = "0.3.31"
 hash-db = { version = "0.16.0", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Branch `"v0.x"` was updated with breaking changes. Pin to the version originally intended when the dep was updated to v0.x: https://github.com/opentensor/frontier/commit/fdf64ac5214d6bf8a8fa0e50766235c01a3268bd#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87eR2533 (expand the Cargo.lock)