### PR TITLE
Bump Polkadot SDK version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "hash-db",
  "log",
@@ -1899,7 +1899,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1909,7 +1909,7 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus-babe",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2018,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.13.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2028,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2045,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3156,7 +3156,7 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
 ]
 
 [[package]]
@@ -3337,7 +3337,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3466,7 +3466,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "41.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "49.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -3580,7 +3580,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "41.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.9.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -3680,7 +3680,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -3721,27 +3721,40 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "34.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse",
  "docify",
  "expander",
+ "frame-support-procedural-core",
  "frame-support-procedural-tools",
  "itertools 0.11.0",
  "macro_magic",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "frame-support-procedural-core"
+version = "34.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
+dependencies = [
+ "cfg-expr",
+ "frame-support-procedural-tools",
+ "proc-macro2",
+ "quote",
  "syn 2.0.104",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.3.0",
@@ -3753,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3763,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3782,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3796,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3806,7 +3819,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.47.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7045,7 +7058,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7063,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7077,7 +7090,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7093,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7108,7 +7121,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7121,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7144,7 +7157,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7174,7 +7187,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7209,7 +7222,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7464,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7482,7 +7495,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7519,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7535,7 +7548,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -7554,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7566,7 +7579,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7587,7 +7600,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7609,7 +7622,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -7618,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7633,7 +7646,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7651,7 +7664,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7666,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -7682,7 +7695,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -7694,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7713,7 +7726,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7728,7 +7741,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8054,7 +8067,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "18.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8065,7 +8078,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bs58",
  "futures",
@@ -8082,7 +8095,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -8107,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -8131,7 +8144,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -8159,7 +8172,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -8179,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "17.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.20",
@@ -8195,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -8224,7 +8237,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8274,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -8286,7 +8299,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "20.0.2"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -8334,7 +8347,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.10.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8369,7 +8382,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8638,7 +8651,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "syn 2.0.104",
  "trybuild",
 ]
@@ -9679,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "32.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "log",
  "sp-core",
@@ -9690,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9721,7 +9734,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "futures",
  "log",
@@ -9743,7 +9756,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.45.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9758,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
@@ -9773,7 +9786,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -9784,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -9795,7 +9808,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.53.1"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -9837,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "fnv",
  "futures",
@@ -9863,7 +9876,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.47.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -9891,7 +9904,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9914,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9943,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -9968,7 +9981,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -9979,7 +9992,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -9992,7 +10005,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.36.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "ahash",
  "array-bytes 6.2.3",
@@ -10026,7 +10039,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -10036,7 +10049,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.52.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -10071,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -10094,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
@@ -10117,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.39.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "polkavm 0.24.0",
  "sc-allocator",
@@ -10130,7 +10143,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.36.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "log",
  "polkavm 0.24.0",
@@ -10141,7 +10154,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.39.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "anyhow",
  "log",
@@ -10157,7 +10170,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "console",
  "futures",
@@ -10173,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "36.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.4",
@@ -10187,7 +10200,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -10215,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.51.1"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -10265,7 +10278,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.49.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -10275,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "ahash",
  "futures",
@@ -10294,7 +10307,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -10315,7 +10328,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -10350,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -10369,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.17.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bs58",
  "bytes",
@@ -10390,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "46.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bytes",
  "fnv",
@@ -10424,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -10433,7 +10446,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "46.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10465,7 +10478,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10485,7 +10498,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -10509,7 +10522,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -10542,13 +10555,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -10557,7 +10570,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.52.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "directories",
@@ -10621,7 +10634,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.39.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10632,7 +10645,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "43.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -10645,14 +10658,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "29.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "chrono",
  "futures",
@@ -10671,7 +10684,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "chrono",
  "console",
@@ -10699,7 +10712,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -10710,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -10727,7 +10740,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -10741,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -10758,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -11385,7 +11398,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "18.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11568,7 +11581,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "docify",
  "hash-db",
@@ -11590,7 +11603,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -11604,7 +11617,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11616,7 +11629,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "27.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -11630,7 +11643,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11642,7 +11655,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -11652,7 +11665,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -11671,7 +11684,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -11685,7 +11698,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11701,7 +11714,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11719,7 +11732,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11736,7 +11749,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11747,7 +11760,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -11778,7 +11791,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -11809,7 +11822,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -11822,17 +11835,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "syn 2.0.104",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.4",
@@ -11841,7 +11854,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11851,7 +11864,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11861,7 +11874,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11873,7 +11886,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11886,7 +11899,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "41.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bytes",
  "docify",
@@ -11898,7 +11911,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -11912,7 +11925,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -11922,7 +11935,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
@@ -11933,7 +11946,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -11942,7 +11955,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.11.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -11952,7 +11965,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11963,7 +11976,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11980,7 +11993,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11993,7 +12006,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12003,7 +12016,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "backtrace",
  "regex",
@@ -12012,7 +12025,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "35.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -12022,7 +12035,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -12051,7 +12064,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "30.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12070,7 +12083,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "Inflector",
  "expander",
@@ -12083,7 +12096,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12097,7 +12110,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -12110,7 +12123,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.46.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "hash-db",
  "log",
@@ -12130,7 +12143,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -12143,7 +12156,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -12154,12 +12167,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12171,7 +12184,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12183,7 +12196,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -12194,7 +12207,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12203,7 +12216,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12217,7 +12230,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "ahash",
  "foldhash",
@@ -12242,7 +12255,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12259,7 +12272,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -12271,7 +12284,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -12283,7 +12296,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "32.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -12457,7 +12470,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "17.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -12478,7 +12491,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "21.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "environmental",
  "frame-support",
@@ -12502,7 +12515,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "20.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -12556,7 +12569,7 @@ dependencies = [
 [[package]]
 name = "stc-shield"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12577,7 +12590,7 @@ dependencies = [
 [[package]]
 name = "stp-shield"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12646,7 +12659,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -12671,12 +12684,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "45.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -12696,7 +12709,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.6"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -12710,7 +12723,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "async-trait",
@@ -12735,7 +12748,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-executive",
@@ -12759,7 +12772,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-genesis-builder",
@@ -12782,7 +12795,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "futures",
  "sc-block-builder",
@@ -12800,7 +12813,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "27.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -13587,7 +13600,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -13598,7 +13611,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "expander",
  "proc-macro-crate 3.3.0",
@@ -15037,7 +15050,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/opentensor/polkadot-sdk?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/opentensor/polkadot-sdk?rev=6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8#6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,95 +90,95 @@ thiserror = "2.0"
 tokio = "1.45.0"
 
 # Substrate Client
-sc-basic-authorship = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-block-builder = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-chain-spec = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-cli = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-client-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-client-db = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-manual-seal = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-executor = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-keystore = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-common = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-sync = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-offchain = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-rpc = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-rpc-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-service = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-telemetry = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-transaction-pool-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-utils = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
+sc-basic-authorship = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-block-builder = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-chain-spec = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-cli = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sc-client-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-client-db = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sc-consensus = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-consensus-manual-seal = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-executor = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-keystore = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-network = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-network-common = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-network-sync = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-offchain = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-rpc = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-rpc-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-service = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sc-telemetry = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-transaction-pool-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+sc-utils = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
 # Substrate Primitive
-sp-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-block-builder = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-blockchain = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-core = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-crypto-hashing = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-database = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-externalities = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-genesis-builder = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-inherents = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-io = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-keyring = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-offchain = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-runtime-interface = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-session = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-state-machine = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-std = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-storage = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-timestamp = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-trie = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-version = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-weights = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-block-builder = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-blockchain = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-consensus = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-core = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-crypto-hashing = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-database = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-externalities = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-genesis-builder = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-inherents = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-io = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-keyring = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-offchain = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-runtime-interface = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-session = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-state-machine = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-std = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-storage = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-timestamp = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-trie = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-version = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+sp-weights = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
 # Substrate FRAME
-frame-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-executive = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-support = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-system = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-aura = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-grandpa = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-sudo = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-timestamp = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-utility = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+frame-executive = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+frame-support = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+frame-system = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+pallet-aura = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+pallet-grandpa = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+pallet-sudo = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+pallet-timestamp = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+pallet-utility = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
 # Substrate Utility
-frame-benchmarking-cli = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-substrate-build-script-utils = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-substrate-frame-rpc-system = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-substrate-test-runtime-client = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-substrate-wasm-builder = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
+frame-benchmarking-cli = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+substrate-build-script-utils = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+substrate-frame-rpc-system = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+substrate-test-runtime-client = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
+substrate-wasm-builder = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8" }
 
-stc-shield = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-stp-shield = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+stc-shield = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+stp-shield = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
 
 # Polkadot
-polkadot-runtime-common = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+polkadot-runtime-common = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
 
 # Cumulus primitives
-cumulus-pallet-weight-reclaim = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+cumulus-pallet-weight-reclaim = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
 
 # XCM
-xcm = { package = "staging-xcm", git = "https://github.com/opentensor/polkadot-sdk", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+xcm = { package = "staging-xcm", git = "https://github.com/opentensor/polkadot-sdk", rev = "6a62332f1ff8b6b2fe1488ee740de1d35e1cecb8", default-features = false }
 
 # Arkworks
 ark-bls12-377 = { version = "0.4.0", default-features = false, features = ["curve"] }


### PR DESCRIPTION
Bump PSDK rev hash to the [latest changes](https://github.com/opentensor/polkadot-sdk/commits/polkadot-stable2506-2-otf-patches/), including the following PRs:

- opentensor/polkadot-sdk#26
- opentensor/polkadot-sdk#27
